### PR TITLE
implement page-view-transition

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -24,6 +24,7 @@
     "lucide-react": "^0.367.0",
     "next": "^14.2.2",
     "next-themes": "^0.3.0",
+    "next-view-transitions": "^0.1.1",
     "query-string": "^9.0.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",

--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -5,6 +5,7 @@ import type { PropsWithChildren } from "react";
 import type { Metadata } from "next";
 
 import { ThemeProvider } from "@/providers/ThemeProvider";
+import { ViewTransitions } from "next-view-transitions";
 import { Toaster } from "@/components/Sonner";
 import { Inter } from "next/font/google";
 
@@ -19,19 +20,21 @@ export const metadata: Metadata = {
 
 function RootLayout({ children }: PropsWithChildren): JSX.Element {
   return (
-    <html lang="en" suppressHydrationWarning>
-      <body className={inter.className}>
-        <ThemeProvider
-          attribute="class"
-          defaultTheme="system"
-          enableSystem
-          disableTransitionOnChange
-        >
-          <ConvexClientProvider>{children}</ConvexClientProvider>
-          <Toaster />
-        </ThemeProvider>
-      </body>
-    </html>
+    <ViewTransitions>
+      <html lang="en" suppressHydrationWarning>
+        <body className={inter.className}>
+          <ThemeProvider
+            attribute="class"
+            defaultTheme="system"
+            enableSystem
+            disableTransitionOnChange
+          >
+            <ConvexClientProvider>{children}</ConvexClientProvider>
+            <Toaster />
+          </ThemeProvider>
+        </body>
+      </html>
+    </ViewTransitions>
   );
 }
 

--- a/apps/web/src/components/ProjectLink.tsx
+++ b/apps/web/src/components/ProjectLink.tsx
@@ -4,8 +4,6 @@ import type { FC, PropsWithChildren } from "react";
 import { ChevronRightIcon } from "@heroicons/react/24/outline";
 import { Button } from "@repo/ui/components/ui/button";
 
-import Link from "next/link";
-
 type ProjectLinkProps = PropsWithChildren & {
   name: string;
   link: any;

--- a/apps/web/src/routes/makeRoute.tsx
+++ b/apps/web/src/routes/makeRoute.tsx
@@ -1,9 +1,10 @@
 /*
 Derived from: https://www.flightcontrol.dev/blog/fix-nextjs-routing-to-have-full-type-safety
 */
+import { Link } from 'next-view-transitions';
 import { z } from "zod";
+
 import queryString from "query-string";
-import Link from "next/link";
 
 type LinkProps = Parameters<typeof Link>[0];
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -117,6 +117,9 @@ importers:
       next-themes:
         specifier: ^0.3.0
         version: 0.3.0(react-dom@18.2.0)(react@18.2.0)
+      next-view-transitions:
+        specifier: ^0.1.1
+        version: 0.1.1(next@14.2.2)(react-dom@18.2.0)(react@18.2.0)
       query-string:
         specifier: ^9.0.0
         version: 9.0.0
@@ -5927,6 +5930,18 @@ packages:
       react: ^16.8 || ^17 || ^18
       react-dom: ^16.8 || ^17 || ^18
     dependencies:
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
+    dev: false
+
+  /next-view-transitions@0.1.1(next@14.2.2)(react-dom@18.2.0)(react@18.2.0):
+    resolution: {integrity: sha512-1rpXhWF8j0VJwJG52c8WeeAYpr1K7o3ub82lahbSoUwAry54TEm1d3mqBbSLLIMl85c3OewkZjxncTHwYFk+IA==}
+    peerDependencies:
+      next: ^14.0.0
+      react: ^18.2.0
+      react-dom: ^18.2.0
+    dependencies:
+      next: 14.2.2(react-dom@18.2.0)(react@18.2.0)
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
     dev: false


### PR DESCRIPTION
### TL;DR

This PR introduces `next-view-transitions` library to the project and adjusts the routing accordingly.

### What changed?

`next-view-transitions` library has been added to the project, providing view transition capability to Next.js applications. All existing `next/link` imports have been replaced with `next-view-transitions` throughout the application. Also, the `RootLayout` has been updated to include the `ViewTransitions` component.

### How to test?

Check out branch, run the application, and navigate between pages to observe the introductions of transitions.

### Why make this change?

To enhance user experience through smooth page transitions between different views in the application.

---

